### PR TITLE
Guice: Eager Singleton vs (Lazy) Singleton

### DIFF
--- a/src/main/java/singletons/CarFactory.java
+++ b/src/main/java/singletons/CarFactory.java
@@ -1,0 +1,17 @@
+package singletons;
+
+import com.google.inject.Inject;
+
+/**
+ * Created by Kristiyan Petkov  <kristiqn.l.petkov@gmail.com> on 08.07.16.
+ */
+public class CarFactory implements Factory {
+  @Inject
+  public CarFactory() {
+    System.out.println("Instantce of CarFactory has been made immediately after the app is booted. ");
+  }
+
+  public void construct() {
+    System.out.println("constructing a car..");
+  }
+}

--- a/src/main/java/singletons/ChineeseRestaurant.java
+++ b/src/main/java/singletons/ChineeseRestaurant.java
@@ -1,0 +1,19 @@
+package singletons;
+
+import com.google.inject.Inject;
+
+import java.sql.ResultSet;
+
+/**
+ * Created by Kristiyan Petkov  <kristiqn.l.petkov@gmail.com> on 08.07.16.
+ */
+public class ChineeseRestaurant implements Restaurant {
+  @Inject
+  public ChineeseRestaurant() {
+    System.out.println("Instance of ChineeseRestaurant is beeing made, only when requested.");
+  }
+
+  public void prepareMeal() {
+
+  }
+}

--- a/src/main/java/singletons/Demo.java
+++ b/src/main/java/singletons/Demo.java
@@ -1,0 +1,16 @@
+package singletons;
+
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+
+/**
+ * Created by Kristiyan Petkov  <kristiqn.l.petkov@gmail.com> on 08.07.16.
+ */
+public class Demo {
+  public static void main(String[] args) {
+    Injector injector = Guice.createInjector(new SingletonModule());
+    Restaurant restaurant = injector.getInstance(Restaurant.class);
+    Factory factory = injector.getInstance(Factory.class);
+    Mammal mammal = injector.getInstance(Mammal.class);
+  }
+}

--- a/src/main/java/singletons/Dog.java
+++ b/src/main/java/singletons/Dog.java
@@ -1,0 +1,15 @@
+package singletons;
+
+/**
+ * Created by Kristiyan Petkov  <kristiqn.l.petkov@gmail.com> on 11.07.16.
+ */
+public class Dog implements Mammal {
+
+  public Dog() {
+    System.out.println("Instance of Dog is being made, only when requested.");
+  }
+
+  public void makeNoise() {
+    System.out.println("Bark bark");
+  }
+}

--- a/src/main/java/singletons/Factory.java
+++ b/src/main/java/singletons/Factory.java
@@ -1,0 +1,8 @@
+package singletons;
+
+/**
+ * Created by Kristiyan Petkov  <kristiqn.l.petkov@gmail.com> on 08.07.16.
+ */
+public interface Factory {
+  void construct();
+}

--- a/src/main/java/singletons/Mammal.java
+++ b/src/main/java/singletons/Mammal.java
@@ -1,0 +1,8 @@
+package singletons;
+
+/**
+ * Created by Kristiyan Petkov  <kristiqn.l.petkov@gmail.com> on 11.07.16.
+ */
+public interface Mammal {
+  void makeNoise();
+}

--- a/src/main/java/singletons/MammalProvider.java
+++ b/src/main/java/singletons/MammalProvider.java
@@ -1,0 +1,14 @@
+package singletons;
+
+import com.google.inject.Provider;
+
+/**
+ * Created by Kristiyan Petkov  <kristiqn.l.petkov@gmail.com> on 11.07.16.
+ */
+public class MammalProvider implements Provider<Mammal> {
+
+  public Mammal get() {
+    Dog dog = new Dog();
+    return dog;
+  }
+}

--- a/src/main/java/singletons/Restaurant.java
+++ b/src/main/java/singletons/Restaurant.java
@@ -1,0 +1,8 @@
+package singletons;
+
+/**
+ * Created by Kristiyan Petkov  <kristiqn.l.petkov@gmail.com> on 08.07.16.
+ */
+public interface Restaurant {
+  void prepareMeal();
+}

--- a/src/main/java/singletons/SingletonModule.java
+++ b/src/main/java/singletons/SingletonModule.java
@@ -1,0 +1,17 @@
+package singletons;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Singleton;
+
+/**
+ * Created by Kristiyan Petkov  <kristiqn.l.petkov@gmail.com> on 08.07.16.
+ */
+public class SingletonModule extends AbstractModule {
+
+  @Override
+  protected void configure() {
+    bind(Factory.class).to(CarFactory.class).asEagerSingleton();
+    bind(Restaurant.class).to(ChineeseRestaurant.class).in(Singleton.class);
+    bind(Mammal.class).toProvider(MammalProvider.class).in(Singleton.class);
+  }
+}


### PR DESCRIPTION
In my PR i made a task, which shows the difference between Singleton and Eager Singleton.
The difference between both is that when binding interface to implementation as eager Singleton `bind(Factory.class).to(CarFactory.class).asEagerSingleton();` , the instance of CarFactory is being made immediately after the app is booted, while when binding as Singleton `    bind(Restaurant.class).to(ChineeseRestaurant.class).in(Singleton.class);` the instance of ChineeseRestaurant is beeing made, only when requested.

MammalProvider
![screenshot from 2016-07-11 11-53-54](https://cloud.githubusercontent.com/assets/12229738/16725046/29e46bb2-475e-11e6-8a95-c2871e085d55.png)



Binding:
![screenshot from 2016-07-11 11-50-20](https://cloud.githubusercontent.com/assets/12229738/16725019/0eef1b22-475e-11e6-8afb-807bb4f42dfd.png)


Demo:
![screenshot from 2016-07-11 11-50-11](https://cloud.githubusercontent.com/assets/12229738/16724989/f3f71bf8-475d-11e6-8e0e-a1377c5b555b.png)

Output:
![screenshot from 2016-07-11 11-49-56](https://cloud.githubusercontent.com/assets/12229738/16724995/fafdbe84-475d-11e6-959f-d21ab1a42a8f.png)

Singletons can be used with anotations too. Example:
![screenshot from 2016-07-13 17-33-34](https://cloud.githubusercontent.com/assets/12229738/16807151/0f2be336-4920-11e6-889c-3bd05c04db61.png)


